### PR TITLE
Removed http-equiv directives from templates

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,7 +11,6 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.5">
-    <meta http-equiv="Cache-control" content="public, max-age=432000">
     {{ hugo.Generator }}
     {{ block "meta" . }} {{ end }}
 

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -2,8 +2,6 @@
 {{ with .Params.author -}} <meta name="author" content="{{ . }}"> {{- end }}
 {{ with .Summary -}} <meta name="description" content="{{ . }}"> {{- end }}
 {{ with .Keywords -}} <meta name="keywords" content="{{ delimit . ", " }}"> {{- end }}
-<meta http-equiv="last-modified" content="{{ .Lastmod }}">
-<meta http-equiv="eTag" content="{{ .File.UniqueID }}">
 {{ end }}
 
 {{ define "includes" }}


### PR DESCRIPTION
I used http-equiv to set HTTP headers related to caching, like
`Cache-Control`, `Last-Modified`, or `ETag`. Turns out that HTML 5 does not
allow this
(https://html.spec.whatwg.org/multipage/semantics.html#pragma-directives).

This is why I removed all http-equiv directives from the code. I have to
adjust the server configuration to handle caching.