### PR TITLE
Added shortcodes for references to other websites

### DIFF
--- a/layouts/shortcodes/referTo.html
+++ b/layouts/shortcodes/referTo.html
@@ -1,0 +1,2 @@
+{{ $reference := anchorize (.Get 0) }}
+<a href="#reference-{{ $reference }}">{{ $reference }}</a>

--- a/layouts/shortcodes/reference.html
+++ b/layouts/shortcodes/reference.html
@@ -1,0 +1,5 @@
+{{ $reference := anchorize (.Get 0) }}
+{{ $source := .Get 1 }}
+<p id="reference-{{ $reference }}">
+    [{{ $reference }}]: <a rel="external" href="{{ $source }}">{{ $source }}</a>
+</p>


### PR DESCRIPTION
I want to distinguish between footnotes and references. The former are for additional notes, while the latter are for reference sources that prove the given information, are the source of the given information or were quoted indirectly.

A third kind of references are direct links. I will use them when I want to point the reader to something directly or when I refer to one of my articles.

Because I want to use the footnotes that are built into Markdown for my definition of footnotes, I created two shortcodes to make it easy to create references.