### PR TITLE
Add new resource: TCP checksum calculator

### DIFF
--- a/content/resources/tcp-checksum-calculator/_index.html
+++ b/content/resources/tcp-checksum-calculator/_index.html
@@ -1,0 +1,139 @@
+---
+title: TCP Checksum Calculator
+summary: Give me the TCP pseudo header and I will calculate the segments's checksum for you.
+keywords:
+- TCP
+- Checksum
+- Tool
+---
+
+<h2>TCP Checksum Calculator</h2>
+
+<link type="text/css" rel="stylesheet" href="./style.css" />
+
+<script src="./calculator.js"></script>
+
+<script>
+    function loadTests() {
+        var scriptTag = document.createElement("script");
+        scriptTag.src = "./tests.js";
+        document.head.appendChild(scriptTag);
+    }
+</script>
+
+<script>
+    function handleSubmit(e) {
+        e.preventDefault();
+
+        const formData = new FormData(e.target);
+
+        const pkg = {
+            "src": formData.get("src"),
+            "dst": formData.get("dst"),
+            "srcPort": formData.get("srcPort"),
+            "dstPort": formData.get("dstPort"),
+            "seq": formData.get("seq"),
+            "ack": formData.get("ack") ?? 0,
+            "flags": formData.getAll("flags"),
+            "window": formData.get("window") ?? 0,
+            "payload": formData.get("payload")
+        };
+
+        const checksum = calcChecksum(pkg);
+
+        document.getElementById("checksum").innerText = "0x" + checksum.toString(16).toUpperCase();
+        document.getElementById("checksum-paragraph").hidden = false;
+
+        return false;
+    }
+</script>
+
+<form id="tcp-packet-form" onsubmit="handleSubmit(event)">
+    <div id="source-address" class="field-container">
+        <label for="source-address-input">IPv4 Source Address:</label>
+        <input id="source-address-input" class="input-left" name="src"
+            type="text" required pattern="(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}"
+            placeholder="172.16.127.1">
+    </div>
+
+    <div id="source-port" class="field-container">
+        <label for="source-port-input">Source Port:</label>
+        <input id="source-port-input" class="input-right" name="srcPort"
+            type="number" required min="0" max="65535"
+            placeholder="1313">
+    </div>
+
+    <div id="destination-address" class="field-container">
+        <label for="destination-address-input">IPv4 Destination Address:</label>
+        <input id="destination-address-input" class="input-left" name="dst"
+            type="text" required pattern="(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}"
+            placeholder="185.137.168.188">
+    </div>
+
+    <div id="destination-port" class="field-container">
+        <label for="destination-port-input">Destination Port:</label>
+        <input id="destination-port-input" class="input-right" name="dstPort"
+            type="number" required min="0" max="65535"
+            placeholder="80">
+    </div>
+
+    <div id="sequence-number" class="field-container">
+        <label for="sequence-number-input">Sequence Number:</label>
+        <input id="sequence-number-input" class="input-left" name="seq"
+            type="number" required min="0" max="4294967295"
+            placeholder="3785974232">
+    </div>
+
+    <div id="acknowledgement-number" class="field-container">
+        <label for="acknowledgement-number-input">Acknowledgement Number:</label>
+        <input id="acknowledgement-number-input" class="input-left" name="ack"
+            type="number" min="0" max="4294967295"
+            placeholder="2789245672">
+    </div>
+
+    <div id="window" class="field-container">
+        <label for="window-input">Window:</label>
+        <input id="window-input" name="window"
+            type="number" min="0" max="65535"
+            placeholder="271">
+    </div>
+
+    <fieldset id="flags" class="checkbox-container">
+        <legend>Flags:</legend>
+        
+        <div id="flags-inner-border">
+            <input id="flag-cwr" type="checkbox" name="flags" value="CWR">
+            <label for="flag-cwr">CWR</label>
+            
+            <input id="flag-ece" type="checkbox" name="flags" value="ECE">
+            <label for="flag-ece">ECE</label>
+            
+            <input id="flag-urg" type="checkbox" name="flags" value="URG">
+            <label for="flag-urg">URG</label>
+            
+            <input id="flag-ack" type="checkbox" name="flags" value="ACK">
+            <label for="flag-ack">ACK</label>
+            
+            <input id="flag-psh" type="checkbox" name="flags" value="PSH">
+            <label for="flag-psh">PSH</label>
+            
+            <input id="flag-rst" type="checkbox" name="flags" value="RST">
+            <label for="flag-rst">RST</label>
+            
+            <input id="flag-syn" type="checkbox" name="flags" value="SYN">
+            <label for="flag-syn">SYN</label>
+            
+            <input id="flag-fin" type="checkbox" name="flags" value="FIN">
+            <label for="flag-fin">FIN</label>
+        </div>
+    </fieldset>
+
+    <div id="payload" class="field-container">
+        <label for="payload-input">Data:</label>
+        <textarea id="payload-input" name="payload" placeholder="Payload as UTF-8 text..."></textarea>
+    </div>
+</form>
+
+<button form="tcp-packet-form" type="submit">Calculate checksum</button>
+
+<p id="checksum-paragraph" hidden>Checksum: <span id="checksum"></span></p>

--- a/content/resources/tcp-checksum-calculator/calculator.js
+++ b/content/resources/tcp-checksum-calculator/calculator.js
@@ -1,0 +1,113 @@
+'use strict';
+
+function calcChecksum(pkg) {
+    function onesComplementSum(a, b) {
+        const c = a + b;
+        return (c & 0xFFFF) + (c >>> 16);
+    }
+
+    const tcpSegment = getTcpSegment(pkg);
+    const pseudoHeader = getPseudoHeader(pkg, tcpSegment.length);
+
+    const pseudoDatagram = pseudoHeader.concat(tcpSegment);
+
+    const words = octetsToWords(pseudoDatagram);
+
+    //TODO Add using normal + and shift only the end result
+    const sum = words.reduce((acc, current) => onesComplementSum(acc, current));
+    const checksum = (~sum) & 0xFFFF;
+    
+    return checksum;
+}
+
+function octetsToWords(octets) {
+    if (octets.length % 2 === 1) {
+        octets.push(0); // padding
+    }
+
+    const result = new Array(octets.length / 2);
+
+    for (let i = 0; i < result.length; i++) {
+        result[i] = (octets[2 * i] << 8) + octets[2 * i + 1];
+    }
+
+    return result;
+}
+    
+function toOctets(number, count) {
+    const words = new Array(count).fill(0);
+
+    let i = count - 1;
+    while (i >= 0 && number > 0) {
+        words[i] = number & 0xFF;
+        number >>>= 8; // >>> is unsigned right shift
+        i--;
+    }
+
+    return words;
+}
+
+function getTcpSegment(pkg) {
+    const srcPort = toOctets(pkg.srcPort, 2);
+    const dstPort = toOctets(pkg.dstPort, 2);
+    const seq = toOctets(pkg.seq, 4);
+    const ack = toOctets(pkg.ack, 4);        
+    const offset = 5; // No options
+    const flags = parseFlags(pkg.flags);
+    const window = toOctets(pkg.window, 2);
+    const checksum = [0, 0];
+    const urgPtr = toOctets(pkg.urgPtr, 2);
+
+    const payload = payloadToOctets(pkg.payload);
+
+    return srcPort.concat(dstPort, seq, ack, (offset << 4), flags, window, checksum, urgPtr, payload);
+
+    function parseFlags(flags) {
+        const flagValues = {
+            "FIN": 0x01, "SYN": 0x02, "RST": 0x04, "PSH": 0x08,
+            "ACK": 0x10, "URG": 0x20, "ECE": 0x40, "CWR": 0x80
+        };
+
+        return flags
+            .map(f => flagValues[f])
+            .reduce((acc, curr) => acc + curr, 0);
+    }
+
+    // Transforms payload into array of bytes
+    // Currently, there is no way to specify the format from the UI
+    function payloadToOctets(payload, format = "utf8") {
+        if (!payload)
+            return [];
+
+        switch (format) {
+            case "utf8": return Array.from(new TextEncoder().encode(payload));
+            case "raw": return parseRawBytes(payload);
+            default: throw "Unknown format: " + format + ".";
+        }
+    }
+
+    function parseRawBytes(payload) {
+        const bytes = [];
+
+        for (let i = 0; i <= payload.length - 2; i += 2) {
+            const b = parseInt(payload.substr(i, 2), 16);
+            bytes.push(b);
+        }
+
+        return bytes;
+    }
+}
+
+function getPseudoHeader(pkg, tcpLength) {
+    const src = parseIPAddress(pkg.src);
+    const dst = parseIPAddress(pkg.dst);
+    const reserved = 0;
+    const protocol = 6; // TCP
+    tcpLength = toOctets(tcpLength, 2);
+
+    return src.concat(dst, reserved, protocol, tcpLength);
+    
+    function parseIPAddress(addr) {
+        return addr.split(".").map(o => o || "0").map(o => parseInt(o));
+    }
+}

--- a/content/resources/tcp-checksum-calculator/tests.js
+++ b/content/resources/tcp-checksum-calculator/tests.js
@@ -1,0 +1,54 @@
+function assertEqual(expected, actual) {
+    if (expected != actual) {
+        throw new Error(`Expected checksum to be 0x${expected.toString(16)}, but got 0x${actual.toString(16)}.`);
+    }
+}
+
+function runTests() {
+    const pkg1 = {
+        "src": "192.168.1.1",
+        "dst": "192.168.1.2",
+        "srcPort": 11500,
+        "dstPort": 80,
+        "seq": 167320,
+        "ack": 0,
+        "flags": ["SYN"],
+        "window": 8192,
+        "urgPtr": 0,
+        "payload": null
+    };
+
+    assertEqual(0x51B8, calcChecksum(pkg1));
+
+    const pkg2 = {
+        "src": "86.105.245.69",
+        "dst": "54.208.45.22",
+        "srcPort": 64500,
+        "dstPort": 7000,
+        "seq": 353127008,
+        "ack": 19402540,
+        "flags": ["SYN", "ACK"],
+        "window": 1024,
+        "urgPtr": 0,
+        "payload": "Hello World!"
+    };
+    
+    assertEqual(0x2335, calcChecksum(pkg2));
+
+    const pkg3 = {
+        "src": "86.105.245.69",
+        "dst": "54.208.45.22",
+        "srcPort": 64500,
+        "dstPort": 7000,
+        "seq": 353127008,
+        "ack": 19402540,
+        "flags": ["SYN", "ACK"],
+        "window": 1024,
+        "urgPtr": 0,
+        "payload": "Hello World"
+    };
+
+    assertEqual(0x2357, calcChecksum(pkg3));
+
+    return "All tests passed.";
+}

--- a/layouts/resources/section.html
+++ b/layouts/resources/section.html
@@ -1,3 +1,8 @@
+{{ define "meta" }}
+{{ with .Summary -}} <meta name="description" content="{{ . }}"> {{- end }}
+{{ with .Keywords -}} <meta name="keywords" content="{{ delimit . ", " }}"> {{- end }}
+{{ end }}
+
 {{ define "includes" }}
 {{ partial "scssLink" "resources" }}
 {{ end }}


### PR DESCRIPTION
I was searching for an easy way to get the TCP checksum for a pseudo-header, but have not found what I was looking for. So I coded it myself.

After filling in the required form fields like source and destination IP addresses and ports, sequence and acknowledgement numbers, the 'window' value, flags, and the payload, the checksum is calculated by the algorithm laid out in RFCs 791 and 1071.

The payload is provided as UTF-8 text. The corresponding JavaScript method can also handle a raw byte string such as the one you get when selecting _Show Packet Bytes..._ in Wireshark and setting the 'Show as' value to 'Raw'.